### PR TITLE
Fix force users generation

### DIFF
--- a/Source/ProjectJedi.csproj
+++ b/Source/ProjectJedi.csproj
@@ -108,6 +108,7 @@
     <Compile Include="ProjectJedi\PawnGhost.cs" />
     <Compile Include="ProjectJedi\Projectile_ForceStorm.cs" />
     <Compile Include="ProjectJedi\ProjectJediDefOf.cs" />
+    <Compile Include="ProjectJedi\ForceDataGenerator.cs" />
     <Compile Include="ProjectJedi\ThinkNode_ModNeedPercentageAbove.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Source/ProjectJedi/CompForceUser.cs
+++ b/Source/ProjectJedi/CompForceUser.cs
@@ -35,7 +35,9 @@ namespace ProjectJedi
             {
                 if (this.forceData == null && this.IsForceUser)
                 {
-                    this.forceData = new ForceData(this);
+                    //this.forceData = new ForceData(this);
+                    // generating a unique force user
+                    this.forceData = ForceDataGenerator.RandomForceData(this);
                 }
 
                 return this.forceData;

--- a/Source/ProjectJedi/CompForceUser.cs
+++ b/Source/ProjectJedi/CompForceUser.cs
@@ -37,7 +37,7 @@ namespace ProjectJedi
                 {
                     //this.forceData = new ForceData(this);
                     // generating a unique force user
-                    this.forceData = ForceDataGenerator.RandomForceData(this);
+                    this.forceData = ForceDataGenerator.ForceDataForUser(this);
                 }
 
                 return this.forceData;

--- a/Source/ProjectJedi/ForceDataGenerator.cs
+++ b/Source/ProjectJedi/ForceDataGenerator.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using Verse;
+
+namespace ProjectJedi
+{
+    public static class ForceDataGenerator
+    {
+        public static ForceData RandomForceData(CompForceUser newUser)
+        {
+            ForceData forceData = new ForceData(newUser);
+
+            // are his powers discovered?
+            // the older the pawn more chance to have his powers discovered
+            if(new IntRange(1, 101).RandomInRange > forceData?.Pawn.ageTracker.AgeBiologicalYears)
+            {
+                return forceData;
+            }
+
+            // generate the level
+            int forceLevel = Mathf.Clamp(forceData.Pawn.skills.skills
+                                                  .Select(skill => skill.Level)
+                                                  .Sum() / forceData.Pawn.skills.skills.Count, 1, 50);
+            forceData.Level = forceLevel;
+
+            //select side
+            forceData.Alignment = new FloatRange(0f, 1f).RandomInRange;
+
+            while(forceLevel != 0)
+            {
+                bool upgradeSkills = new IntRange(0, 2).RandomInRange == 0 ? false : true;
+
+                if (upgradeSkills)
+                {
+                    var skill = forceData.Skills.RandomElement();
+                    if(skill?.level < 5)
+                    {
+                        skill.level++;
+                        forceLevel--;
+                    }
+                }
+                else
+                {
+                    var power = forceData.Powers.RandomElement();
+                    if(power?.level < 3)
+                    {
+                        forceData.Pawn.GetComp<CompForceUser>()?.LevelUpPower(power);
+                        forceLevel--;
+                    }
+                }
+            }
+
+            return forceData;
+        } 
+    }
+}

--- a/Source/ProjectJedi/ForceDataGenerator.cs
+++ b/Source/ProjectJedi/ForceDataGenerator.cs
@@ -1,33 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
-using Verse;
+﻿using Verse;
 
 namespace ProjectJedi
 {
     public static class ForceDataGenerator
     {
-        public static ForceData RandomForceData(CompForceUser newUser)
+        public static ForceData ForceDataForUser(CompForceUser newUser)
         {
             ForceData forceData = new ForceData(newUser);
-
-            // are his powers discovered?
-            // the older the pawn more chance to have his powers discovered
-            if(new IntRange(1, 101).RandomInRange > forceData?.Pawn.ageTracker.AgeBiologicalYears)
+            
+            // has the pawn begun training in the way of the force?
+            if(IsPawnForceSensitive(newUser.AbilityUser))
             {
                 return forceData;
             }
 
             // generate the level
-            int forceLevel = Mathf.Clamp(forceData.Pawn.skills.skills
-                                                  .Select(skill => skill.Level)
-                                                  .Sum() / forceData.Pawn.skills.skills.Count, 1, 50);
+            int forceLevel = GetPawnForceLevel(newUser.AbilityUser);
             forceData.Level = forceLevel;
-
-            //select side
-            forceData.Alignment = new FloatRange(0f, 1f).RandomInRange;
 
             while(forceLevel != 0)
             {
@@ -53,7 +42,46 @@ namespace ProjectJedi
                 }
             }
 
+            //select side
+            forceData.Alignment = new FloatRange(0f, 1f).RandomInRange;
+
             return forceData;
-        } 
+        }
+        
+        public static bool IsPawnForceSensitive(Pawn pawn)
+        {
+            var sensitiveTrait = pawn.story.traits.GetTrait(ProjectJediDefOf.PJ_ForceSensitive);
+            if(sensitiveTrait == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static int GetPawnForceLevel(Pawn pawn)
+        {
+            int maxLevel = 0;
+
+            var jediTrait = pawn.story.traits.GetTrait(ProjectJediDefOf.PJ_JediTrait);
+            var sithTrait = pawn.story.traits.GetTrait(ProjectJediDefOf.PJ_SithTrait);
+            var grayTrait = pawn.story.traits.GetTrait(ProjectJediDefOf.PJ_GrayTrait);
+
+            if(jediTrait != null)
+            {
+                maxLevel = jediTrait.Degree;
+            }
+            if(sithTrait != null)
+            {
+                maxLevel = sithTrait.Degree;
+            }
+            if(grayTrait != null)
+            {
+                maxLevel = grayTrait.Degree;
+            }
+
+            maxLevel *= 5;
+            return new IntRange(maxLevel - 4, maxLevel).RandomInRange;
+        }
     }
 }


### PR DESCRIPTION
Now when a new pawn is spawned with one of the force traits he has some skills learned based on the trait he has thus adding more immersive storytelling.

if he has the trait Force Sensitive then it will spawn with level 0 as usual
but if he has one of the other traits depending on the trait degree he will have a bigger or lower level
(ex. now a Sith Lord will have a level of 11-15 not 0 as it was before)